### PR TITLE
Remove 'selection' support for iOS since it breaks this dependency in…

### DIFF
--- a/src/Components/Editor.js
+++ b/src/Components/Editor.js
@@ -515,6 +515,7 @@ export class Editor extends React.Component {
       show: this.shouldMentionsShow(state, props),
     };
 
+    console.log(this.state);
     return (
       <View style={customStyles.container}>
         {this.shouldMentionsShow(state, props) ? (
@@ -540,7 +541,8 @@ export class Editor extends React.Component {
                   {...this.props}
                   {...baseInputProps}
                   scrollEnabled={false}
-                  selection={this.state.selection}
+                  // FIXME: As of updating to React-Native 0.63.3, selection is broken on iOS too (https://github.com/facebook/react-native/issues/29063).
+                  // selection={this.state.selection}
                 />
               ) : (
                 <TextInput

--- a/src/Components/Editor.js
+++ b/src/Components/Editor.js
@@ -515,7 +515,6 @@ export class Editor extends React.Component {
       show: this.shouldMentionsShow(state, props),
     };
 
-    console.log(this.state);
     return (
       <View style={customStyles.container}>
         {this.shouldMentionsShow(state, props) ? (


### PR DESCRIPTION
… the 0.63 react-native versions.